### PR TITLE
Update kubernetes.sh

### DIFF
--- a/kubernetes.sh
+++ b/kubernetes.sh
@@ -158,7 +158,7 @@ function helm_cluster_logout {
 }
 
 function helm_init_namespace {
-	$HELM repo add stable https://kubernetes-charts.storage.googleapis.com/
+	$HELM repo add stable https://charts.helm.sh/stable
 	$HELM repo update
 }
 


### PR DESCRIPTION
$ helm_init_namespace
Error: looks like "https://kubernetes-charts.storage.googleapis.com/" is not a valid chart repository or cannot be reached: failed to fetch https://kubernetes-charts.storage.googleapis.com/index.yaml : 403 Forbidden

https://stackoverflow.com/questions/61954440/how-to-resolve-https-kubernetes-charts-storage-googleapis-com-is-not-a-valid