### PR TITLE
Allow multiple excludes for ssh_copy_from_docker

### DIFF
--- a/misc.sh
+++ b/misc.sh
@@ -45,6 +45,7 @@ function ssh_copy_from_docker () {
 	if [ -z "$DEPLOY_EXCLUDE" ]; then
 		ssh -o Port=${SSH_PORT} -o BatchMode=yes -o StrictHostKeyChecking=no root@${DEPLOY_SERVER} 'DOCKER_TMP_DIR=$(mktemp -d -t docker.XXXXXXXXXX); DEPLOY_TMP_CONTAINER=$(docker create '${DEPLOY_IMAGE}'); docker export ${DEPLOY_TMP_CONTAINER} | tar -C ${DOCKER_TMP_DIR} --strip-components='${DEPLOY_STRIP}' -xf - '${DEPLOY_SOURCE}'; rsync -a --delete ${DOCKER_TMP_DIR}/ '${DEPLOY_TARGET}'/; chmod 755 '${DEPLOY_TARGET}'; docker rm ${DEPLOY_TMP_CONTAINER}; rm -rf ${DOCKER_TMP_DIR}'
 	else
-		ssh -o Port=${SSH_PORT} -o BatchMode=yes -o StrictHostKeyChecking=no root@${DEPLOY_SERVER} 'DOCKER_TMP_DIR=$(mktemp -d -t docker.XXXXXXXXXX); DEPLOY_TMP_CONTAINER=$(docker create '${DEPLOY_IMAGE}'); docker export ${DEPLOY_TMP_CONTAINER} | tar -C ${DOCKER_TMP_DIR} --strip-components='${DEPLOY_STRIP}' -xf - '${DEPLOY_SOURCE}'; rsync -a --delete --exclude '${DEPLOY_EXCLUDE}' ${DOCKER_TMP_DIR}/ '${DEPLOY_TARGET}'/; chmod 755 '${DEPLOY_TARGET}'; docker rm ${DEPLOY_TMP_CONTAINER}; rm -rf ${DOCKER_TMP_DIR}'
+		printf -v DEPLOY_EXCLUDE '\x2D\x2Dexclude %s ' ${DEPLOY_EXCLUDE[@]}
+		ssh -o Port=${SSH_PORT} -o BatchMode=yes -o StrictHostKeyChecking=no root@${DEPLOY_SERVER} 'DOCKER_TMP_DIR=$(mktemp -d -t docker.XXXXXXXXXX); DEPLOY_TMP_CONTAINER=$(docker create '${DEPLOY_IMAGE}'); docker export ${DEPLOY_TMP_CONTAINER} | tar -C ${DOCKER_TMP_DIR} --strip-components='${DEPLOY_STRIP}' -xf - '${DEPLOY_SOURCE}'; rsync -a --delete '${DEPLOY_EXCLUDE}' ${DOCKER_TMP_DIR}/ '${DEPLOY_TARGET}'/; chmod 755 '${DEPLOY_TARGET}'; docker rm ${DEPLOY_TMP_CONTAINER}; rm -rf ${DOCKER_TMP_DIR}'
 	fi
 }


### PR DESCRIPTION
Example expansion:

DEPLOY_EXCLUDE='dirone'; printf -v DEPLOY_EXCLUDE '\x2D\x2Dexclude %s ' ${DEPLOY_EXCLUDE[@]}; echo "$DEPLOY_EXCLUDE"
--exclude dirone

DEPLOY_EXCLUDE='dirone dirtwo dirthree dir/subdir'; printf -v DEPLOY_EXCLUDE '\x2D\x2Dexclude %s ' ${DEPLOY_EXCLUDE[@]}; echo "$DEPLOY_EXCLUDE"
--exclude dirone --exclude dirtwo --exclude dirthree --exclude dir/subdir

----

man bash
/printf

...
       printf [-v var] format [arguments]
              ...
              The -v option causes the output to be assigned to the
              variable var rather than being printed to the standard output.
              ...
              The  format  is  reused as necessary to consume all of the arguments.